### PR TITLE
Add replay-past-events-in-order

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-smart-contracts "1.0.11-SNAPSHOT"
+(defproject district0x/district-server-smart-contracts "1.0.12-SNAPSHOT"
   :description "district0x server module for handling smart-contracts"
   :url "https://github.com/district0x/district-server-smart-contracts"
   :license {:name "Eclipse Public License"

--- a/src/district/server/smart_contracts.cljs
+++ b/src/district/server/smart_contracts.cljs
@@ -2,7 +2,7 @@
   (:require [cljs-web3.core :as web3]
             [cljs-web3.eth :as web3-eth]
             [cljs-web3.utils :refer [js->cljkk camel-case]]
-            [cljs.core.async :refer [<! timeout]]
+            [cljs.core.async :refer [<! timeout] :as async]
             [cljs.core.match :refer-macros [match]]
             [cljs.nodejs :as nodejs]
             [cljs.pprint]
@@ -279,3 +279,31 @@
 
     (aset event-filter "stopWatching" #(reset! stopped? true)) ;; So we can detect stopWatching was called
     event-filter))
+
+(defn replay-past-events-in-order
+  "Given a collection of filters get all past
+  events from the filters, sorts them by :block-number :transaction-index :log-index
+  and callback each of them in order."
+  [event-filters ev-callback]
+
+  ;; install all get filters
+  (let [all-evs-ch (for [filter event-filters]
+                     (let [pch (async/promise-chan)]
+                       (.get filter
+                             (fn [err res]
+                               (when err (println (js/Error. err)))
+                               (let [filter-events (js->cljkk res)]
+                                 (async/put! pch filter-events))))
+                       pch))]
+
+    ;; go chan by chan collecting events
+    (go-loop [all-events []
+              [ch & r] all-evs-ch]
+      (if ch
+        (let [evs (async/<! ch)]
+          (recur (into all-events evs) r)) ;; keep collecting
+
+        ;; no more channels to read, sort and callback
+        (doseq [e (->> all-events
+                       (sort-by (juxt :block-number :transaction-index :log-index)))]
+            (callback e))))))

--- a/src/district/server/smart_contracts.cljs
+++ b/src/district/server/smart_contracts.cljs
@@ -284,7 +284,7 @@
   "Given a collection of filters get all past
   events from the filters, sorts them by :block-number :transaction-index :log-index
   and callback each of them in order."
-  [event-filters ev-callback]
+  [event-filters callback]
 
   ;; install all get filters
   (let [all-evs-ch (for [filter event-filters]


### PR DESCRIPTION
I tried it in memefactory like 
```clojure
(let [last-block-number (last-block-number)
        filters-builders [(partial eternal-db/change-applied-event :param-change-registry-db)
                          (partial eternal-db/change-applied-event :meme-registry-db)

                          (partial registry/meme-constructed-event [:meme-registry :meme-registry-fwd])
                          (partial registry/meme-minted-event [:meme-registry :meme-registry-fwd])
                          (partial registry/challenge-created-event [:meme-registry :meme-registry-fwd])
                          (partial registry/vote-committed-event [:meme-registry :meme-registry-fwd])
                          (partial registry/vote-revealed-event [:meme-registry :meme-registry-fwd])
                          (partial registry/vote-amount-claimed-event [:meme-registry :meme-registry-fwd])
                          (partial registry/vote-reward-claimed-event [:meme-registry :meme-registry-fwd])
                          (partial registry/challenge-reward-claimed-event [:meme-registry :meme-registry-fwd])

                          meme-auction-factory/meme-auction-started-event
                          meme-auction-factory/meme-auction-buy-event
                          meme-auction-factory/meme-auction-canceled-event

                          meme-token/meme-token-transfer-event]
        past-events-filters (->> filters-builders
                                 (map #(apply % [{} {:from-block 0 :to-block (dec last-block-number)}])))]
    (replay-past-events-in-order past-events-filters (fn [e] (println (:type e)))))
```