### PR TITLE
Adds `:crash-on-event-fail?`  option to replay-past-events-in-order

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-smart-contracts "1.2.4-SNAPSHOT"
+(defproject district0x/district-server-smart-contracts "1.2.5-SNAPSHOT"
   :description "district0x server module for handling smart-contracts"
   :url "https://github.com/district0x/district-server-smart-contracts"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
So we don't carry the error, also useful for dev