### PR TITLE
Fix contract-event-in-tx bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,14 +228,11 @@ Opts you can pass:
 
 ## Development
 ```bash
-# To start REPL and run tests
+# Setup
 lein deps
-lein repl
-(start-tests!)
+docker run --name=ganache -p 8545:8545 trufflesuite/ganache-cli:v6.12.1 -p 8545
 
-# In other terminal
-node tests-compiled/run-tests.js
-
-# To run tests without REPL
-lein doo node "tests" once
+# To run tests
+truffle migrate --network ganache --reset
+lein doo node "nodejs-tests" once
 ```

--- a/contracts/MyContract.sol
+++ b/contracts/MyContract.sol
@@ -6,7 +6,7 @@ contract MyContract {
   uint public counter;
 
   event onCounterIncremented(uint theCounter);
-  event onSpecialEvent(uint someParam);
+  event onSpecialEvent(uint indexed param1, uint indexed param2, uint param3, uint param4);
 
   function MyContract(uint _counter) {
     counter = _counter;
@@ -30,7 +30,7 @@ contract MyContract {
     incrementCounter(i);
   }
 
-  function fireSpecialEvent(uint someParam) {
-    onSpecialEvent(someParam);
+  function fireSpecialEvent(uint param1, uint param2, uint param3, uint param4) {
+    onSpecialEvent(param1, param2, param3, param4);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "district-server-smart-contracts",
-  "version": "1.2.4-SNAPSHOT",
+  "version": "1.2.5-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/district/server/smart_contracts.cljs
+++ b/src/district/server/smart_contracts.cljs
@@ -201,7 +201,7 @@
                  (let [{:keys [:logs :inputs]} (web3-helpers/js->cljkk tx-receipt)]
                    (some (fn [{:keys [:topics :data] :as log}]
                            (when (= signature (first topics))
-                             (let [return-values (web3-eth/decode-log @web3 (:inputs event-interface) data topics)]
+                             (let [return-values (web3-eth/decode-log @web3 (:inputs event-interface) data (drop 1 topics))]
                                (web3-helpers/return-values->clj return-values event-interface))))
                     logs))))))
 

--- a/truffle.js
+++ b/truffle.js
@@ -13,5 +13,10 @@ module.exports = {
       gasPrice: 20e9, // 20 gwei, default for ganache
       network_id: '*'
     }
-  }
+  },
+  compilers: {
+      solc: {
+        version: "0.4.24",
+      }
+    }
 };


### PR DESCRIPTION
The key change here is from `topics` to `(drop 1 topics)` as `web3-eth/decode-log` argument.

If we look at [web3.eth.abi.decodeLog(inputs, hexString, topics) docs](https://web3js.readthedocs.io/en/v1.2.0/web3-eth-abi.html#decodelog), it says that
```
topics - Array: An array with the index parameter topics of the log, without the topic[0]
if its a non-anonymous event, otherwise with topic[0].
```

Since we only use non-anonymous events, we should be dropping the first topic, i.e., the event signature (question - do we need to support anonymous events?).

It is not obvious there is a bug if we only use events with no indexed parameters in testing. In that case all parameters get stored to the "data" field of the log and it doesn't matter whether we're dropping the first topic or not. When we use at least one indexed parameter in the event, it gets stored in the "topics" field and we need to appropriately drop the first topic, otherwise the event data get decoded incorrectly and subtle errors can occur, which happened to me when upgrading Name Bazaar to current `district-server-smart-contracts`. The `contract-event-in-tx` mechanism was different before, therefore this issue didn't occur.