### PR TITLE
Add back contract-events-from-tx

### DIFF
--- a/contracts/MyContract.sol
+++ b/contracts/MyContract.sol
@@ -33,4 +33,9 @@ contract MyContract {
   function fireSpecialEvent(uint param1, uint param2, uint param3, uint param4) {
     onSpecialEvent(param1, param2, param3, param4);
   }
+
+  function fireSpecialEventTwice(uint param1, uint param2, uint param3, uint param4) {
+    onSpecialEvent(param1, param2, param3, param4);
+    onSpecialEvent(param4, param3, param2, param1);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "district-server-smart-contracts",
-  "version": "1.2.5-SNAPSHOT",
+  "version": "1.2.7-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-smart-contracts "1.2.6-SNAPSHOT"
+(defproject district0x/district-server-smart-contracts "1.2.7-SNAPSHOT"
   :description "district0x server module for handling smart-contracts"
   :url "https://github.com/district0x/district-server-smart-contracts"
   :license {:name "Eclipse Public License"

--- a/test/tests/all.cljs
+++ b/test/tests/all.cljs
@@ -45,6 +45,10 @@
                  increment-counter-tx (<! (smart-contracts/contract-send :my-contract :increment-counter [1] {:gas 5000000}))
                  special-event-tx (<! (smart-contracts/contract-send :my-contract :fire-special-event [2 3 4 5] {:gas 500000}))
                  decoded-special-event (<! (smart-contracts/contract-event-in-tx :my-contract :on-special-event special-event-tx))
+
+                 special-event-tx-twice (<! (smart-contracts/contract-send :my-contract :fire-special-event-twice [2 3 4 5] {:gas 500000}))
+                 decoded-special-events-all (<! (smart-contracts/contract-events-in-tx :my-contract :on-special-event special-event-tx-twice))
+                 ; decoded-special-events-all {}
                  _ (<! (smart-contracts/replay-past-events-in-order events (fn [error {:keys [:args :event]}]
                                                                              (case event
                                                                                :on-counter-incremented
@@ -93,6 +97,9 @@
              (is (= "5" five))
 
              (is (= {:param-1 "2" :param-2 "3" :param-3 "4" :param-4 "5"} decoded-special-event))
+
+             (is (= {:param-1 "2" :param-2 "3" :param-3 "4" :param-4 "5"} (first decoded-special-events-all)))
+             (is (= {:param-1 "5" :param-2 "4" :param-3 "3" :param-4 "2"} (last decoded-special-events-all)))
 
              (is (= "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef" (string/lower-case target)))
              (is (= (string/lower-case my-contract-address) (string/lower-case forwarder-target)))


### PR DESCRIPTION
`contract-events-in-tx` was originally added in `3dae35a7d6c8a26fca6f15346396b2271b201dad`
  - https://github.com/district0x/district-server-smart-contracts/commit/3dae35a7d6c8a26fca6f15346396b2271b201dad#diff-418cdb98146d75c4492f38501b1c0dd13625bb1112c1da93dfb194a9af535ed6R236

> Also the readme still documents this method.

But then probably accidentally removed in `f3350f3c378b5432226a35afbfebc7266745b96b`
  - https://github.com/district0x/district-server-smart-contracts/commit/f3350f3c378b5432226a35afbfebc7266745b96b#diff-418cdb98146d75c4492f38501b1c0dd13625bb1112c1da93dfb194a9af535ed6L291-L304

It's a useful method to get all events of certain name. So this change
implements it reusing existing logic from `contract-event-from-tx`