### PR TITLE
Enrich event only if not nil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-server-smart-contracts "1.2.8-SNAPSHOT"
+(defproject district0x/district-server-smart-contracts "1.2.9-SNAPSHOT"
   :description "district0x server module for handling smart-contracts"
   :url "https://github.com/district0x/district-server-smart-contracts"
   :license {:name "Eclipse Public License"

--- a/src/district/server/smart_contracts.cljs
+++ b/src/district/server/smart_contracts.cljs
@@ -181,10 +181,11 @@
                                (fn [error evt]
                                  (if callbacks
                                    ;; if we have callbacks registered, fire this event in all of them
-                                   (let [enriched-evt (->> evt
+                                   (let [enriched-evt (if evt (->> evt
                                                            web3-helpers/js->cljkk
                                                            (#(assoc % :latest-event? latest-event?))
-                                                           (enrich-event-log contract contract-instance))]
+                                                           (enrich-event-log contract contract-instance))
+                                                        evt)]
                                      (doseq [callback callbacks]
                                        (callback error enriched-evt)))
 


### PR DESCRIPTION
Event (evt) might be nil when an error announcement is coming from the websocket. For example, if the websocket disconnects.
This PR adds a nil check before enriching the event to handle that case.