### PR TITLE
iterate on callback return

### DIFF
--- a/lib_version.clj
+++ b/lib_version.clj
@@ -1,4 +1,4 @@
 (ns lib-version)
 
 (def lib 'district0x/district-server-smart-contracts) ; ends up as <group-id>/<artifact-id> in pom.xml
-(def version "1.4.0-SNAPSHOT")
+(def version "1.4.1-SNAPSHOT")

--- a/src/district/server/smart_contracts.cljs
+++ b/src/district/server/smart_contracts.cljs
@@ -311,7 +311,7 @@
         (do
           (when (fn? callback)
             (doseq [log chunk-logs]
-              (let [res (try
+              (doseq [res (try
                           (if-let [?error (:error? (meta log))]
                             (callback ?error nil)
                             (callback nil log))


### PR DESCRIPTION
I thought `callback` return a value. But `callback` return a collection of values.

So it is not like `callback` return value or `chan`, but collection containing values and channels.

Because of that events didn't wait for processing when there was a `chan` in collection.