### PR TITLE
Implement backoff retry and sequential fetch

### DIFF
--- a/lib_version.clj
+++ b/lib_version.clj
@@ -1,4 +1,4 @@
 (ns lib-version)
 
 (def lib 'district0x/district-server-smart-contracts) ; ends up as <group-id>/<artifact-id> in pom.xml
-(def version "1.4.2-SNAPSHOT")
+(def version "1.4.3-SNAPSHOT")


### PR DESCRIPTION
Some web3 providers force rate limits such that the amount of request you can do per second is capped. In that case, the provider sends an error if many requests are done in very short time.

This pull requests implements a retry mechanism with exponential backoff in case an error is received from the provider.

Additionally, a config parameter has been added to allow fetching the events sequentially to limit the amount of requests. That is, a request is not attempted until previous one is completed.